### PR TITLE
feat(): enable implicit redirect flow on web

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ pkceEnable: true
 ...
 ```
 
+Supported on Web with the new method `redirectFlowCodeListener` which should be called on your app init process
+so it watches for the URL queryString `code` to generate an `access_token` correctly.
+
 Please be aware that some providers (OneDrive, Auth0) allow **Code Flow + PKCE** only for native apps. Web apps have to use implicit flow.
 
 ### Important

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -6,6 +6,14 @@ export interface GenericOAuth2Plugin {
    */
   authenticate(options: OAuth2AuthenticateOptions): Promise<any>;
   /**
+   * Handle OAuth implicit flow
+   * @param {OAuth2RedirectAuthenticationOptions} options
+   * @returns {Promise<any>} the token endpoint response
+   */
+  handleRedirectAuthentication(
+    options: OAuth2RedirectAuthenticationOptions,
+  ): Promise<any>;
+  /**
    * Get a new access token based on the given refresh token.
    * @param {OAuth2RefreshTokenOptions} options
    * @returns {Promise<any>} the token endpoint response
@@ -21,6 +29,14 @@ export interface GenericOAuth2Plugin {
     options: OAuth2AuthenticateOptions,
     id_token?: string,
   ): Promise<boolean>;
+}
+
+export interface OAuth2RedirectAuthenticationOptions
+  extends OAuth2AuthenticateOptions {
+  /**
+   * The URL where we get the code
+   */
+  response_url: string;
 }
 
 export interface OAuth2RefreshTokenOptions {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -6,11 +6,11 @@ export interface GenericOAuth2Plugin {
    */
   authenticate(options: OAuth2AuthenticateOptions): Promise<any>;
   /**
-   * Handle OAuth implicit flow
+   * Listens for OAuth implicit redirect flow queryString CODE to generate an access_token
    * @param {OAuth2RedirectAuthenticationOptions} options
    * @returns {Promise<any>} the token endpoint response
    */
-  handleRedirectAuthentication(
+  redirectFlowCodeListener(
     options: OAuth2RedirectAuthenticationOptions,
   ): Promise<any>;
   /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -11,7 +11,7 @@ export interface GenericOAuth2Plugin {
    * @returns {Promise<any>} the token endpoint response
    */
   redirectFlowCodeListener(
-    options: OAuth2RedirectAuthenticationOptions,
+    options: ImplicitFlowRedirectOptions,
   ): Promise<any>;
   /**
    * Get a new access token based on the given refresh token.
@@ -31,8 +31,7 @@ export interface GenericOAuth2Plugin {
   ): Promise<boolean>;
 }
 
-export interface OAuth2RedirectAuthenticationOptions
-  extends OAuth2AuthenticateOptions {
+export interface ImplicitFlowRedirectOptions extends OAuth2AuthenticateOptions {
   /**
    * The URL where we get the code
    */

--- a/src/web-utils.ts
+++ b/src/web-utils.ts
@@ -75,7 +75,7 @@ export class WebUtils {
 
   static setCodeVerifier(code: string): boolean {
     try {
-      sessionStorage.setItem(`I_Capacitor_GenericOAuth2Plugin_PKCE`, code);
+      window.sessionStorage.setItem(`I_Capacitor_GenericOAuth2Plugin_PKCE`, code);
       return true;
     } catch (err) {
       return false;
@@ -83,11 +83,11 @@ export class WebUtils {
   }
 
   static clearCodeVerifier(): void {
-    sessionStorage.removeItem(`I_Capacitor_GenericOAuth2Plugin_PKCE`);
+    window.sessionStorage.removeItem(`I_Capacitor_GenericOAuth2Plugin_PKCE`);
   }
 
   static getCodeVerifier(): string | null {
-    return sessionStorage.getItem(`I_Capacitor_GenericOAuth2Plugin_PKCE`);
+    return window.sessionStorage.getItem(`I_Capacitor_GenericOAuth2Plugin_PKCE`);
   }
 
   /**

--- a/src/web-utils.ts
+++ b/src/web-utils.ts
@@ -73,6 +73,23 @@ export class WebUtils {
     return body;
   }
 
+  static setCodeVerifier(code: string): boolean {
+    try {
+      sessionStorage.setItem(`I_Capacitor_GenericOAuth2Plugin_PKCE`, code);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  static clearCodeVerifier(): void {
+    sessionStorage.removeItem(`I_Capacitor_GenericOAuth2Plugin_PKCE`);
+  }
+
+  static getCodeVerifier(): string | null {
+    return sessionStorage.getItem(`I_Capacitor_GenericOAuth2Plugin_PKCE`);
+  }
+
   /**
    * Public only for testing
    */
@@ -172,7 +189,13 @@ export class WebUtils {
       'pkceEnabled',
     );
     if (webOptions.pkceEnabled) {
-      webOptions.pkceCodeVerifier = this.randomString(64);
+      const pkceCode = this.getCodeVerifier();
+      if (pkceCode) {
+        webOptions.pkceCodeVerifier = pkceCode;
+      } else {
+        webOptions.pkceCodeVerifier = this.randomString(64);
+        this.setCodeVerifier(webOptions.pkceCodeVerifier);
+      }
       if (CryptoUtils.HAS_SUBTLE_CRYPTO) {
         await CryptoUtils.deriveChallenge(webOptions.pkceCodeVerifier).then(
           c => {

--- a/src/web.ts
+++ b/src/web.ts
@@ -4,7 +4,7 @@ import type {
   OAuth2AuthenticateOptions,
   GenericOAuth2Plugin,
   OAuth2RefreshTokenOptions,
-  OAuth2RedirectAuthenticationOptions,
+  ImplicitFlowRedirectOptions,
 } from './definitions';
 import type { WebOptions } from './web-utils';
 import { WebUtils } from './web-utils';
@@ -28,7 +28,7 @@ export class GenericOAuth2Web extends WebPlugin implements GenericOAuth2Plugin {
   }
 
   async redirectFlowCodeListener(
-    options: OAuth2RedirectAuthenticationOptions,
+    options: ImplicitFlowRedirectOptions,
   ): Promise<any> {
     this.webOptions = await WebUtils.buildWebOptions(options);
     return new Promise((resolve, reject) => {

--- a/src/web.ts
+++ b/src/web.ts
@@ -4,6 +4,7 @@ import type {
   OAuth2AuthenticateOptions,
   GenericOAuth2Plugin,
   OAuth2RefreshTokenOptions,
+  OAuth2RedirectAuthenticationOptions,
 } from './definitions';
 import type { WebOptions } from './web-utils';
 import { WebUtils } from './web-utils';
@@ -23,6 +24,25 @@ export class GenericOAuth2Web extends WebPlugin implements GenericOAuth2Plugin {
   async refreshToken(_options: OAuth2RefreshTokenOptions): Promise<any> {
     return new Promise<any>((_resolve, reject) => {
       reject(new Error('Functionality not implemented for PWAs yet'));
+    });
+  }
+
+  async handleRedirectAuthentication(
+    options: OAuth2RedirectAuthenticationOptions,
+  ): Promise<any> {
+    this.webOptions = await WebUtils.buildWebOptions(options);
+    return new Promise((resolve, reject) => {
+      const urlParamObj = WebUtils.getUrlParams(options.response_url);
+      if (urlParamObj) {
+        const code = urlParamObj.code;
+        if (code) {
+          this.getAccessToken(urlParamObj, resolve, reject, code);
+        } else {
+          reject(new Error('Oauth Code parameter was not present in url.'));
+        }
+      } else {
+        reject(new Error('Oauth Parameters where not present in url.'));
+      }
     });
   }
 
@@ -109,59 +129,14 @@ export class GenericOAuth2Web extends WebPlugin implements GenericOAuth2Plugin {
                   this.webOptions.state
                 ) {
                   if (this.webOptions.accessTokenEndpoint) {
-                    const self = this;
                     const authorizationCode =
                       authorizationRedirectUrlParamObj.code;
                     if (authorizationCode) {
-                      const tokenRequest = new XMLHttpRequest();
-                      tokenRequest.onload = function () {
-                        if (this.status === 200) {
-                          const accessTokenResponse = JSON.parse(this.response);
-                          if (self.webOptions.logsEnabled) {
-                            self.doLog(
-                              'Access token response:',
-                              accessTokenResponse,
-                            );
-                          }
-                          self.requestResource(
-                            accessTokenResponse.access_token,
-                            resolve,
-                            reject,
-                            authorizationRedirectUrlParamObj,
-                            accessTokenResponse,
-                          );
-                        }
-                      };
-                      tokenRequest.onerror = function () {
-                        // always log error because of CORS hint
-                        self.doLog(
-                          'ERR_GENERAL: See client logs. It might be CORS. Status text: ' +
-                            this.statusText,
-                        );
-                        reject(new Error('ERR_GENERAL'));
-                      };
-                      tokenRequest.open(
-                        'POST',
-                        this.webOptions.accessTokenEndpoint,
-                        true,
-                      );
-                      tokenRequest.setRequestHeader(
-                        'accept',
-                        'application/json',
-                      );
-                      tokenRequest.setRequestHeader(
-                        'cache-control',
-                        'no-cache',
-                      );
-                      tokenRequest.setRequestHeader(
-                        'content-type',
-                        'application/x-www-form-urlencoded',
-                      );
-                      tokenRequest.send(
-                        WebUtils.getTokenEndpointData(
-                          this.webOptions,
-                          authorizationCode,
-                        ),
+                      this.getAccessToken(
+                        authorizationRedirectUrlParamObj,
+                        resolve,
+                        reject,
+                        authorizationCode,
                       );
                     } else {
                       reject(new Error('ERR_NO_AUTHORIZATION_CODE'));
@@ -199,6 +174,48 @@ export class GenericOAuth2Web extends WebPlugin implements GenericOAuth2Plugin {
   }
 
   private readonly MSG_RETURNED_TO_JS = 'Returned to JS:';
+
+  private getAccessToken(
+    authorizationRedirectUrlParamObj: { [p: string]: string } | undefined,
+    resolve: (value: any) => void,
+    reject: (reason?: any) => void,
+    authorizationCode: string,
+  ) {
+    const tokenRequest = new XMLHttpRequest();
+    tokenRequest.onload = () => {
+      WebUtils.clearCodeVerifier();
+      if (tokenRequest.status === 200) {
+        const accessTokenResponse = JSON.parse(tokenRequest.response);
+        if (this.webOptions.logsEnabled) {
+          this.doLog('Access token response:', accessTokenResponse);
+        }
+        this.requestResource(
+          accessTokenResponse.access_token,
+          resolve,
+          reject,
+          authorizationRedirectUrlParamObj,
+          accessTokenResponse,
+        );
+      }
+    };
+    tokenRequest.onerror = () => {
+      this.doLog(
+        'ERR_GENERAL: See client logs. It might be CORS. Status text: ' +
+          tokenRequest.statusText,
+      );
+      reject(new Error('ERR_GENERAL'));
+    };
+    tokenRequest.open('POST', this.webOptions.accessTokenEndpoint, true);
+    tokenRequest.setRequestHeader('accept', 'application/json');
+    tokenRequest.setRequestHeader('cache-control', 'no-cache');
+    tokenRequest.setRequestHeader(
+      'content-type',
+      'application/x-www-form-urlencoded',
+    );
+    tokenRequest.send(
+      WebUtils.getTokenEndpointData(this.webOptions, authorizationCode),
+    );
+  }
 
   private requestResource(
     accessToken: string,

--- a/src/web.ts
+++ b/src/web.ts
@@ -27,7 +27,7 @@ export class GenericOAuth2Web extends WebPlugin implements GenericOAuth2Plugin {
     });
   }
 
-  async handleRedirectAuthentication(
+  async redirectFlowCodeListener(
     options: OAuth2RedirectAuthenticationOptions,
   ): Promise<any> {
     this.webOptions = await WebUtils.buildWebOptions(options);


### PR DESCRIPTION
Enables the implicit redirect authentication flow for web, when using `windowTarget: '_self'`

Closes 
- https://github.com/capacitor-community/generic-oauth2/issues/107