### PR TITLE
feat: Add an option to remove the cache-control header

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,12 @@ These parameters are overrideable in every platform
 
 **Platform Web**
 
-| parameter     | default  | required | description                            | since |
-| ------------- | -------- | -------- | -------------------------------------- | ----- |
-| windowOptions |          |          | e.g. width=500,height=600,left=0,top=0 |       |
-| windowTarget  | `_blank` |          |                                        |       |
-| windowReplace |          |          |                                        | 3.0.0 |
+| parameter              | default  | required | description                                                                                     | since |
+|------------------------|----------|----------|-------------------------------------------------------------------------------------------------|-------|
+| windowOptions          |          |          | e.g. width=500,height=600,left=0,top=0                                                          |       |
+| windowTarget           | `_blank` |          |                                                                                                 |       |
+| windowReplace          |          |          |                                                                                                 | 3.0.0 |
+| sendCacheControlHeader | true     |          | Whether to send the cache control header with the token request, unsupported by some providers. | 6.1.0 |
 
 **Platform Android**
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -136,6 +136,10 @@ export interface WebOption extends OAuth2AuthenticateBaseOptions {
    * Options for the window target. Defaults to _blank
    */
   windowTarget?: string;
+  /**
+   * Whether to send the cache control header with the token request, unsupported by some providers. Defaults to true.
+   */
+  sendCacheControlHeader?: boolean;
 }
 
 export interface AndroidOptions extends OAuth2AuthenticateBaseOptions {

--- a/src/web-utils.test.ts
+++ b/src/web-utils.test.ts
@@ -154,6 +154,22 @@ describe('web options', () => {
       expect(webOptions.additionalParameters['emptyParam']).toBeUndefined();
     });
   });
+
+  it('must have the sendCacheControlHeader enabled by default', async () => {
+    WebUtils.buildWebOptions(oneDriveOptions).then(webOptions => {
+      expect(webOptions.sendCacheControlHeader).toBeTruthy();
+    });
+  });
+
+  it('must allow the sendCacheControlHeader to be set to false', async () => {
+    WebUtils.buildWebOptions({
+      web: {
+        sendCacheControlHeader: false,
+      },
+    }).then(webOptions => {
+      expect(webOptions.sendCacheControlHeader).toBeFalsy();
+    });
+  });
 });
 
 describe('Url param extraction', () => {

--- a/src/web-utils.ts
+++ b/src/web-utils.ts
@@ -171,6 +171,9 @@ export class WebUtils {
       configOptions,
       'pkceEnabled',
     );
+    webOptions.sendCacheControlHeader =
+      this.getOverwritableValue(configOptions, 'sendCacheControlHeader') ??
+      webOptions.sendCacheControlHeader;
     if (webOptions.pkceEnabled) {
       webOptions.pkceCodeVerifier = this.randomString(64);
       if (CryptoUtils.HAS_SUBTLE_CRYPTO) {
@@ -311,6 +314,7 @@ export class WebOptions {
   resourceUrl: string;
   responseType: string;
   scope: string;
+  sendCacheControlHeader = true;
   state: string;
   redirectUrl: string;
   logsEnabled: boolean;

--- a/src/web.ts
+++ b/src/web.ts
@@ -149,10 +149,12 @@ export class GenericOAuth2Web extends WebPlugin implements GenericOAuth2Plugin {
                         'accept',
                         'application/json',
                       );
-                      tokenRequest.setRequestHeader(
-                        'cache-control',
-                        'no-cache',
-                      );
+                      if (this.webOptions.sendCacheControlHeader) {
+                        tokenRequest.setRequestHeader(
+                          'cache-control',
+                          'no-cache',
+                        );
+                      }
                       tokenRequest.setRequestHeader(
                         'content-type',
                         'application/x-www-form-urlencoded',


### PR DESCRIPTION
Fixes https://github.com/capacitor-community/generic-oauth2/issues/228

Adds a new option `sendCacheControlHeader` with default `true`, that can be used to disable the `cache-control` header in the Token request.

This should fix some issues using this library to connect with Spotify or Keycloak.